### PR TITLE
Add zero state for all music page

### DIFF
--- a/app/components/TracksTable.vue
+++ b/app/components/TracksTable.vue
@@ -2,8 +2,26 @@
   <div class="overflow-x-auto lg:overflow-x-visible w-full">
     <div v-if="loading" class="text-neutral-500 p-4">Loading tracks...</div>
 
-    <div v-else-if="tracks.length === 0" class="text-neutral-500 p-4">
-      {{ isOwnProfile ? 'No tracks uploaded yet.' : 'No tracks available.' }}
+    <!-- Zero State -->
+    <div v-else-if="tracks.length === 0" class="py-16 w-full text-center">
+      <div class="max-w-md mx-auto">
+        <h3 class="text-lg font-medium mb-2 text-neutral-300">
+          {{ isOwnProfile ? 'No tracks uploaded yet' : 'No tracks available' }}
+        </h3>
+        <p class="text-neutral-500 text-sm mb-6">
+          {{ isOwnProfile 
+            ? 'Start building your music library by uploading your first track.' 
+            : 'This user hasn\'t uploaded any tracks yet.' 
+          }}
+        </p>
+        <button 
+          v-if="isOwnProfile"
+          @click="handleUploadClick"
+          class="px-4 py-2 bg-amber-500 hover:bg-amber-600 text-neutral-900 font-medium rounded transition-colors cursor-pointer"
+        >
+          Upload Music
+        </button>
+      </div>
     </div>
 
     <div v-else class="w-fit lg:w-full">
@@ -119,6 +137,12 @@ const handlePlayClick = async (track: any, index: number) => {
     // Load the queue and start playing from this track
     await loadQueue(props.tracks, props.sourceId, index)
   }
+}
+
+const handleUploadClick = () => {
+  // Dispatch event to open upload modal
+  const event = new CustomEvent('open-upload-modal')
+  window.dispatchEvent(event)
 }
 </script>
 

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -462,11 +462,17 @@ onMounted(async () => {
   window.addEventListener('edit-track', ((event: CustomEvent) => {
     handleEditTrack(event.detail)
   }) as EventListener)
+  
+  // Listen for upload modal open events
+  window.addEventListener('open-upload-modal', (() => {
+    openModal()
+  }) as EventListener)
 })
 
 // Cleanup on unmount
 onUnmounted(() => {
   auth.cleanup()
   window.removeEventListener('edit-track', handleEditTrack as EventListener)
+  window.removeEventListener('open-upload-modal', openModal as EventListener)
 })
 </script>


### PR DESCRIPTION
Add a zero state to the "All Music" library page to improve user experience when no tracks are present.

---
Linear Issue: [VEN-17](https://linear.app/madebyporter/issue/VEN-17/add-zero-state-for-all-music-library)

<a href="https://cursor.com/background-agent?bcId=bc-d71eb51e-40c6-499e-81c2-3530c0c5ec1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d71eb51e-40c6-499e-81c2-3530c0c5ec1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

