### PR TITLE
SSR software/kits lists for Google indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,3 +195,5 @@ Check out the [deployment documentation](https://nuxt.com/docs/getting-started/d
 - 0.54.0
   - Server-side rendering of software and kits list pages for crawlers
   - SEO metadata (title, description, canonical, Open Graph) on list pages
+- 0.54.1
+  - Fixed admin Manage Submissions empty queue when admin role loads after mount

--- a/README.md
+++ b/README.md
@@ -73,3 +73,125 @@ bun run preview
 ```
 
 Check out the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.
+
+## Version History
+
+- 0.0.0
+  - Initial project scaffold
+- 0.1.0
+  - Tag system for resources
+- 0.2.0
+  - OS tags for resources
+- 0.3.0
+  - Filter and sort for resources
+- 0.4.0
+  - Primary navigation
+- 0.5.0
+  - Resource submission flow
+- 0.6.0
+  - Search keyboard shortcut
+- 0.7.0
+  - Pricing formatting with regex and hard filter on software
+- 0.8.0
+  - Mobile styles
+- 0.9.0
+  - User area UI
+  - User logins and authentication
+- 0.10.0
+  - Admin roles and permissions
+- 0.11.0
+  - Google Analytics
+- 0.12.0
+  - SEO metadata and favicons
+- 0.13.0
+  - Rebuilt tagging system
+  - Image drag and drop for submissions
+- 0.14.0
+  - User profiles
+  - Creators table linking resources to creators
+- 0.15.0
+  - "I use this" feature with public use counts
+- 0.16.0
+  - Migrated data layer to Supabase with improved initialization and error handling
+- 0.17.0
+  - Dark mode
+- 0.18.0
+  - Enhanced search and cross-component communication
+- 0.19.0
+  - Resource management and editing
+  - ManageSubmissions admin interface
+- 0.20.0
+  - MasterDrawer modal system
+- 0.21.0
+  - Custom price sorting
+- 0.22.0
+  - Upgraded project to Nuxt 4 structure
+- 0.23.0
+  - Music upload and editing
+- 0.24.0
+  - Collections management for tracks
+- 0.25.0
+  - Music player
+- 0.26.0
+  - Music metadata extraction and handling
+- 0.27.0
+  - Track version grouping with auto-hide for older versions
+- 0.28.0
+  - Authentication flow with email confirmation
+- 0.29.0
+  - Zero state with upload button for empty tracks table
+- 0.30.0
+  - Player shuffle and queue improvements
+- 0.31.0
+  - Track status management and filtering
+- 0.32.0
+  - Bulk selection and removal of tracks
+- 0.33.0
+  - Server-side rendering and SEO for user profiles, collections, and tracks
+- 0.34.0
+  - Software listing on user profile pages
+- 0.35.0
+  - Bio and social links on user profiles
+- 0.36.0
+  - Profile visibility settings and members section
+- 0.37.0
+  - Signup with user type selection and profile creation
+- 0.38.0
+  - Download sample functionality
+- 0.39.0
+  - SearchModal for site-wide search
+- 0.40.0
+  - Resource detail pages with comments
+- 0.41.0
+  - Software sidebar with scroll position management
+- 0.42.0
+  - Collection sharing and invitations
+- 0.43.0
+  - Account and collection settings
+- 0.44.0
+  - Filter and sort handlers for music pages
+  - Clear All confirmation dialog
+- 0.45.0
+  - Track comments
+- 0.46.0
+  - PostHog analytics integration
+- 0.47.0
+  - Support feedback form with Notion integration
+- 0.48.0
+  - Daily Resend contact sync
+- 0.49.0
+  - Drag-and-drop upload with musical key extraction
+- 0.50.0
+  - "Latest Versions Only" filter for music tracks
+- 0.51.0
+  - Persisted filter and sort preferences for music tracks
+- 0.52.0
+  - Track versioning logic in uploads
+  - Improved artwork handling in music components
+- 0.53.0
+  - Fixed software page canonical URLs for Google indexing
+  - Added dynamic sitemap.xml
+  - Added robots.txt with sitemap reference
+- 0.54.0
+  - Server-side rendering of software and kits list pages for crawlers
+  - SEO metadata (title, description, canonical, Open Graph) on list pages

--- a/app/components/Database.vue
+++ b/app/components/Database.vue
@@ -203,10 +203,10 @@ const useCounts = ref<{[key: number]: number}>({})
 const userUsedResources = ref<{[key: number]: boolean}>({})
 const isSupabaseReady = ref(false)
 
-const fetchResources = async () => {
+const runResourceQuery = async (): Promise<Resource[]> => {
   if (!supabase) {
     console.error('Database: Supabase client not initialized')
-    return
+    return []
   }
 
   try {
@@ -362,8 +362,7 @@ const fetchResources = async () => {
     }
 
     if (!data) {
-      resources.value = [];
-      return;
+      return [];
     }
 
     
@@ -415,23 +414,30 @@ const fetchResources = async () => {
       
     }
 
-    resources.value = processedData
-
-    // Update use counts
-    await fetchUseCounts()
+    return processedData
 
   } catch (error) {
     console.error('Database: Error fetching resources:', error)
-    resources.value = []
+    return []
   }
+}
+
+// Assign query results to state and refresh use counts (used for interactive updates)
+const fetchResources = async () => {
+  resources.value = await runResourceQuery()
+  await fetchUseCounts()
 }
 
 // Initialize Supabase
 onMounted(async () => {
   if (supabase) {
     isSupabaseReady.value = true
-    await fetchResources()
-  } else {
+    // Resources are populated server-side via useAsyncData; only refetch if empty
+    if (resources.value.length) {
+      await fetchUseCounts()
+    } else {
+      await fetchResources()
+    }
   }
 })
 
@@ -649,6 +655,16 @@ const getResourceDetailUrl = (resource: Resource): string => {
   
   const basePath = typePathMap[resource.type.slug] || '/software'
   return `${basePath}/${resource.slug}`
+}
+
+// Fetch initial resources server-side so crawlers receive the full list in HTML
+const { data: ssrResources } = await useAsyncData<Resource[]>(
+  `software-resources-${props.type ?? 'all'}`,
+  () => runResourceQuery(),
+  { default: () => [] as Resource[] }
+)
+if (ssrResources.value) {
+  resources.value = ssrResources.value
 }
 
 // Expose methods and state for parent components

--- a/app/components/DatabaseGrid.vue
+++ b/app/components/DatabaseGrid.vue
@@ -186,10 +186,10 @@ interface UserResource {
   resource_id: number
 }
 
-const fetchResources = async () => {
+const runResourceQuery = async (): Promise<Resource[]> => {
   if (!supabase) {
     console.error('DatabaseGrid: Supabase client not initialized')
-    return
+    return []
   }
 
   try {
@@ -345,8 +345,7 @@ const fetchResources = async () => {
     }
 
     if (!data) {
-      resources.value = [];
-      return;
+      return [];
     }
 
     // Process results
@@ -396,12 +395,17 @@ const fetchResources = async () => {
       
     }
 
-    resources.value = processedData
-    await fetchUseCounts()
+    return processedData
   } catch (error) {
     console.error('DatabaseGrid: Error fetching resources:', error)
-    resources.value = []
+    return []
   }
+}
+
+// Assign query results to state and refresh use counts (used for interactive updates)
+const fetchResources = async () => {
+  resources.value = await runResourceQuery()
+  await fetchUseCounts()
 }
 
 const fetchUseCounts = async () => {
@@ -607,8 +611,12 @@ const extractNumericPrice = (priceStr: string): number => {
 // Initialize
 onMounted(async () => {
   if (supabase) {
-    await fetchResources()
-  } else {
+    // Resources are populated server-side via useAsyncData; only refetch if empty
+    if (resources.value.length) {
+      await fetchUseCounts()
+    } else {
+      await fetchResources()
+    }
   }
 })
 
@@ -616,6 +624,16 @@ onMounted(async () => {
 watch(() => auth.user, async () => {
   await fetchUseCounts()
 })
+
+// Fetch initial resources server-side so crawlers receive the full list in HTML
+const { data: ssrResources } = await useAsyncData<Resource[]>(
+  `kits-resources-${props.type ?? 'all'}`,
+  () => runResourceQuery(),
+  { default: () => [] as Resource[] }
+)
+if (ssrResources.value) {
+  resources.value = ssrResources.value
+}
 
 // Expose methods for parent component
 defineExpose({

--- a/app/components/FilterSort.vue
+++ b/app/components/FilterSort.vue
@@ -301,6 +301,10 @@ import IconLinux from './IconLinux.vue'
 import { useSupabase } from '~/utils/supabase'
 import { useAuth } from '~/composables/useAuth'
 import { useAnalytics } from '~/composables/useAnalytics'
+import {
+  getDefaultFilterSortParams,
+  useFilterSortCookie,
+} from '~/composables/useFilterSortPersistence'
 import { ref, onMounted, reactive, computed, watch } from 'vue'
 import MasterDrawer from './MasterDrawer.vue'
 import ConfirmDialog from './ConfirmDialog.vue'
@@ -308,6 +312,15 @@ import ConfirmDialog from './ConfirmDialog.vue'
 // Reference to the MasterDrawer component
 const drawerRef = ref(null)
 const showClearAllConfirm = ref(false)
+const musicFilterCookie = useFilterSortCookie('music')
+const softwareFilterCookie = useFilterSortCookie('software')
+const kitsFilterCookie = useFilterSortCookie('kits')
+
+const activeFilterCookie = computed(() => {
+  if (props.context === 'music') return musicFilterCookie
+  if (props.context === 'software') return softwareFilterCookie
+  return kitsFilterCookie
+})
 
 const props = defineProps({
   show: {
@@ -442,52 +455,66 @@ const fetchStatuses = async () => {
   }
 }
 
-// Load saved filters from localStorage
+// Reset form fields to defaults without persisting
+const resetFormToDefaults = () => {
+  const defaults = getDefaultFilterSortParams()
+  sortBy.value = defaults.sort.sortBy
+  sortDirection.value = defaults.sort.sortDirection
+  filters.price.free = defaults.filters.price.free
+  filters.price.paid = defaults.filters.price.paid
+  filters.os = [...defaults.filters.os]
+  filters.tags = [...defaults.filters.tags]
+  filters.genre = [...defaults.filters.genre]
+  filters.bpm.min = defaults.filters.bpm.min
+  filters.bpm.max = defaults.filters.bpm.max
+  filters.key = [...defaults.filters.key]
+  filters.mood = [...defaults.filters.mood]
+  filters.year.min = defaults.filters.year.min
+  filters.year.max = defaults.filters.year.max
+  filters.status = [...defaults.filters.status]
+  filters.latestVersionOnly = defaults.filters.latestVersionOnly
+}
+
+// Load saved filters from cookie
 const loadSavedFilters = () => {
-  if (typeof window === 'undefined') return // SSR guard
-  
   try {
-    const savedFiltersKey = `filterSort_${props.context}`
-    const savedData = localStorage.getItem(savedFiltersKey)
-    
-    if (savedData) {
-      const parsed = JSON.parse(savedData)
-      
-      // Restore sort
-      if (parsed.sort) {
-        sortBy.value = parsed.sort.sortBy || 'created_at'
-        sortDirection.value = parsed.sort.sortDirection || 'desc'
-      }
-      
-      // Restore filters based on context
-      if (parsed.filters) {
-        // Software/Kits filters
-        if (props.context !== 'music') {
-          if (parsed.filters.price) {
-            filters.price.free = parsed.filters.price.free || false
-            filters.price.paid = parsed.filters.price.paid || false
-          }
-          if (parsed.filters.os) filters.os = [...parsed.filters.os]
-          if (parsed.filters.tags) filters.tags = [...parsed.filters.tags]
+    const parsed = activeFilterCookie.value.value
+
+    if (!parsed) {
+      resetFormToDefaults()
+      return
+    }
+
+    if (parsed.sort) {
+      sortBy.value = parsed.sort.sortBy || 'created_at'
+      sortDirection.value = parsed.sort.sortDirection || 'desc'
+    }
+
+    if (parsed.filters) {
+      if (props.context !== 'music') {
+        if (parsed.filters.price) {
+          filters.price.free = parsed.filters.price.free || false
+          filters.price.paid = parsed.filters.price.paid || false
         }
-        
-        // Music filters
-        if (props.context === 'music') {
-          if (parsed.filters.genre) filters.genre = [...parsed.filters.genre]
-          if (parsed.filters.bpm) {
-            filters.bpm.min = parsed.filters.bpm.min
-            filters.bpm.max = parsed.filters.bpm.max
-          }
-          if (parsed.filters.key) filters.key = [...parsed.filters.key]
-          if (parsed.filters.mood) filters.mood = [...parsed.filters.mood]
-          if (parsed.filters.year) {
-            filters.year.min = parsed.filters.year.min
-            filters.year.max = parsed.filters.year.max
-          }
-          if (parsed.filters.status) filters.status = [...parsed.filters.status]
-          if (parsed.filters.latestVersionOnly != null) {
-            filters.latestVersionOnly = parsed.filters.latestVersionOnly
-          }
+        if (parsed.filters.os) filters.os = [...parsed.filters.os]
+        if (parsed.filters.tags) filters.tags = [...parsed.filters.tags]
+      }
+
+      if (props.context === 'music') {
+        if (parsed.filters.genre) filters.genre = [...parsed.filters.genre]
+        if (parsed.filters.bpm) {
+          filters.bpm.min = parsed.filters.bpm.min
+          filters.bpm.max = parsed.filters.bpm.max
+        }
+        if (parsed.filters.key) filters.key = [...parsed.filters.key]
+        if (parsed.filters.mood) filters.mood = [...parsed.filters.mood]
+        if (parsed.filters.year) {
+          filters.year.min = parsed.filters.year.min
+          filters.year.max = parsed.filters.year.max
+        }
+        if (parsed.filters.status) filters.status = [...parsed.filters.status]
+        if (parsed.filters.latestVersionOnly != null) {
+          filters.latestVersionOnly = parsed.filters.latestVersionOnly
         }
       }
     }
@@ -496,34 +523,27 @@ const loadSavedFilters = () => {
   }
 }
 
-// Save filters to localStorage
+// Save filters to cookie
 const saveFilters = () => {
-  if (typeof window === 'undefined') return // SSR guard
-  
   try {
-    const savedFiltersKey = `filterSort_${props.context}`
-    const dataToSave = {
+    activeFilterCookie.value.value = {
       sort: {
         sortBy: sortBy.value,
-        sortDirection: sortDirection.value
+        sortDirection: sortDirection.value,
       },
       filters: {
-        // Software/Kits filters
         price: { ...filters.price },
         os: [...filters.os],
         tags: [...filters.tags],
-        // Music filters
         genre: [...filters.genre],
         bpm: { ...filters.bpm },
         key: [...filters.key],
         mood: [...filters.mood],
         year: { ...filters.year },
         status: [...filters.status],
-        latestVersionOnly: filters.latestVersionOnly
-      }
+        latestVersionOnly: filters.latestVersionOnly,
+      },
     }
-    
-    localStorage.setItem(savedFiltersKey, JSON.stringify(dataToSave))
   } catch (error) {
     console.error('FilterSort: Error saving filters:', error)
   }
@@ -556,6 +576,12 @@ onMounted(async () => {
   await fetchTags()
   await fetchStatuses()
   loadSavedFilters()
+})
+
+watch(() => props.show, (isOpen) => {
+  if (isOpen) {
+    loadSavedFilters()
+  }
 })
 
 // Filter tags based on input
@@ -661,7 +687,7 @@ const applyFiltersAndSort = () => {
   }
   
   
-  // Save filters to localStorage for persistence
+  // Save filters to cookie for persistence
   saveFilters()
   
   // First emit the filters
@@ -687,25 +713,7 @@ const applyFiltersAndSort = () => {
 
 // Clear all filters and reset to defaults (called after user confirms)
 const performClearAll = () => {
-  sortBy.value = 'created_at'
-  sortDirection.value = 'desc'
-  // Software/Kits filters
-  filters.price.free = false
-  filters.price.paid = false
-  filters.os = []
-  filters.tags = []
-  // Music filters
-  filters.genre = []
-  filters.bpm.min = null
-  filters.bpm.max = null
-  filters.key = []
-  filters.mood = []
-  filters.year.min = null
-  filters.year.max = null
-  filters.status = []
-  filters.latestVersionOnly = false
-
-  // Save cleared state to localStorage
+  resetFormToDefaults()
   saveFilters()
 }
 </script>

--- a/app/components/LibraryHeader.vue
+++ b/app/components/LibraryHeader.vue
@@ -10,15 +10,26 @@
       <p class="text-sm text-neutral-500 hidden md:flex items-center">
         {{ count }} {{ count === 1 ? itemLabel : itemLabel + 's' }}
       </p>
-      <Button
-        v-if="filterContext"
-        variant="secondary"
-        size="sm"
-        class="btn px-3! py-1.5! text-sm h-full max-h-10 self-stretch"
-        @click="emit('open-filter-sort')"
-      >
-        Filter & Sort
-      </Button>
+      <div v-if="filterContext" id="ui_filter" class="flex items-stretch gap-px">
+        <Button
+          variant="secondary"
+          size="sm"
+          class="btn px-3! py-1.5! text-sm h-full max-h-10 self-stretch"
+          @click="emit('open-filter-sort')"
+        >
+          Filter & Sort
+        </Button>
+        <Button
+          v-if="showClearFilters"
+          variant="secondary"
+          size="sm"
+          class="btn px-2.5! py-1.5! text-sm h-full max-h-10 self-stretch shrink-0"
+          title="Clear filters"
+          @click="emit('clear-filters')"
+        >
+          <Xmark class="w-4 h-4" />
+        </Button>
+      </div>
       <Button
         v-if="showAnalyticsToggle"
         variant="secondary"
@@ -83,7 +94,7 @@
 </template>
 
 <script setup lang="ts">
-import { StatsReport } from '@iconoir/vue'
+import { StatsReport, Xmark } from '@iconoir/vue'
 import { useAnalytics } from '~/composables/useAnalytics'
 
 const props = withDefaults(defineProps<{
@@ -100,6 +111,7 @@ const props = withDefaults(defineProps<{
   showAnalyticsToggle?: boolean
   analyticsMode?: boolean
   analyticsPage?: 'profile' | 'collection'
+  showClearFilters?: boolean
 }>(), {
   itemLabel: 'track',
   showViewModeSelector: true,
@@ -108,6 +120,7 @@ const props = withDefaults(defineProps<{
   showAnalyticsToggle: false,
   analyticsMode: false,
   analyticsPage: 'profile',
+  showClearFilters: false,
 })
 
 const { capture } = useAnalytics()
@@ -117,6 +130,7 @@ const emit = defineEmits<{
   'update:viewMode': [value: 'final' | 'all']
   'update:analyticsMode': [value: boolean]
   'open-filter-sort': []
+  'clear-filters': []
   'open-settings': []
 }>()
 

--- a/app/components/ManageSubmissions.vue
+++ b/app/components/ManageSubmissions.vue
@@ -143,7 +143,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue'
+import { ref, watch } from 'vue'
 import { useSupabase } from '~/utils/supabase'
 import MasterDrawer from './MasterDrawer.vue'
 
@@ -302,21 +302,28 @@ const formatDate = (dateString) => {
   }
 }
 
-// Watch for drawer open to fetch users
+// Fetch pending submissions once admin auth is ready (isAdmin can load after mount)
+watch(
+  () => props.canEdit,
+  (canEdit) => {
+    if (canEdit) {
+      fetchResources()
+      if (props.show) {
+        fetchUsers()
+      }
+    } else {
+      loading.value = false
+      resources.value = []
+    }
+  },
+  { immediate: true }
+)
+
+// Refetch when drawer opens so queue stays current
 watch(() => props.show, (newVal) => {
   if (newVal && props.canEdit) {
-    fetchUsers()
-  }
-})
-
-onMounted(() => {
-  if (props.canEdit) {
     fetchResources()
-    if (props.show) {
-      fetchUsers()
-    }
-  } else {
-    loading.value = false
+    fetchUsers()
   }
 })
 </script> 

--- a/app/composables/useFilterSortPersistence.ts
+++ b/app/composables/useFilterSortPersistence.ts
@@ -1,0 +1,105 @@
+import type { Ref } from 'vue'
+
+export type FilterSortContext = 'software' | 'kits' | 'music'
+
+export interface FilterSortParams {
+  sort: {
+    sortBy: string
+    sortDirection: 'asc' | 'desc'
+  }
+  filters: {
+    price: { free: boolean; paid: boolean }
+    os: string[]
+    tags: string[]
+    genre: string[]
+    bpm: { min: number | null; max: number | null }
+    key: string[]
+    mood: string[]
+    year: { min: number | null; max: number | null }
+    status: (number | null)[]
+    latestVersionOnly: boolean
+  }
+}
+
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
+
+export function getDefaultFilterSortParams(): FilterSortParams {
+  return {
+    sort: {
+      sortBy: 'created_at',
+      sortDirection: 'desc',
+    },
+    filters: {
+      price: { free: false, paid: false },
+      os: [],
+      tags: [],
+      genre: [],
+      bpm: { min: null, max: null },
+      key: [],
+      mood: [],
+      year: { min: null, max: null },
+      status: [],
+      latestVersionOnly: false,
+    },
+  }
+}
+
+export function useFilterSortCookie(context: FilterSortContext) {
+  return useCookie<FilterSortParams | null>(`bbx_filterSort_${context}`, {
+    maxAge: COOKIE_MAX_AGE,
+    sameSite: 'lax',
+    default: () => null,
+  })
+}
+
+export function migrateFilterSortFromLocalStorage(
+  context: FilterSortContext,
+  cookie: Ref<FilterSortParams | null>
+) {
+  if (typeof window === 'undefined') return
+
+  const legacyKey = `filterSort_${context}`
+  const legacy = localStorage.getItem(legacyKey)
+  if (!legacy) return
+
+  try {
+    const parsed = JSON.parse(legacy) as FilterSortParams
+    if (!cookie.value && parsed) {
+      cookie.value = parsed
+    }
+    localStorage.removeItem(legacyKey)
+  } catch {
+    localStorage.removeItem(legacyKey)
+  }
+}
+
+export function hasActiveFilterSort(
+  params: FilterSortParams | null | undefined,
+  context: FilterSortContext
+): boolean {
+  if (!params) return false
+
+  const { sort, filters } = params
+  const nonDefaultSort = sort.sortBy !== 'created_at' || sort.sortDirection !== 'desc'
+
+  if (context === 'music') {
+    return nonDefaultSort || !!(
+      filters.latestVersionOnly ||
+      filters.genre?.length > 0 ||
+      filters.bpm?.min != null ||
+      filters.bpm?.max != null ||
+      filters.key?.length > 0 ||
+      filters.mood?.length > 0 ||
+      filters.year?.min != null ||
+      filters.year?.max != null ||
+      filters.status?.length > 0
+    )
+  }
+
+  return nonDefaultSort || !!(
+    filters.price?.free ||
+    filters.price?.paid ||
+    filters.os?.length > 0 ||
+    filters.tags?.length > 0
+  )
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -164,6 +164,12 @@ import { useAnalytics } from '~/composables/useAnalytics'
 import { useToast } from '~/composables/useToast'
 import { setPendingSignupEmail } from '~/utils/authStorage'
 import { usePlayer } from '~/composables/usePlayer'
+import {
+  getDefaultFilterSortParams,
+  hasActiveFilterSort,
+  migrateFilterSortFromLocalStorage,
+  useFilterSortCookie,
+} from '~/composables/useFilterSortPersistence'
 import Player from '~/components/Player.vue'
 import Toast from '~/components/Toast.vue'
 import TrackCommentsDrawer from '~/components/TrackCommentsDrawer.vue'
@@ -216,6 +222,7 @@ interface FilterSortParams {
     mood: string[]
     year: { min: number | null; max: number | null }
     latestVersionOnly?: boolean
+    status?: (number | null)[]
   }
 }
 
@@ -321,8 +328,54 @@ const currentFilters = ref({
   key: [] as string[],
   mood: [] as string[],
   year: { min: null as number | null, max: null as number | null },
-  latestVersionOnly: false
+  latestVersionOnly: false,
+  status: [] as (number | null)[],
 })
+
+const musicFilterCookie = useFilterSortCookie('music')
+const softwareFilterCookie = useFilterSortCookie('software')
+const kitsFilterCookie = useFilterSortCookie('kits')
+
+const activeFilterSortCookie = computed(() => {
+  const ctx = filterSortContext.value
+  if (ctx === 'music') return musicFilterCookie
+  if (ctx === 'software') return softwareFilterCookie
+  if (ctx === 'kits') return kitsFilterCookie
+  return null
+})
+
+const hasActiveFilterSortState = computed(() => {
+  const ctx = filterSortContext.value
+  if (!ctx) return false
+  return hasActiveFilterSort(activeFilterSortCookie.value?.value, ctx)
+})
+
+const clearFilterSort = () => {
+  const ctx = filterSortContext.value
+  if (!ctx) return
+
+  const cookie = activeFilterSortCookie.value
+  if (cookie) {
+    cookie.value = null
+  }
+
+  const defaults = getDefaultFilterSortParams()
+  currentSort.value = { ...defaults.sort }
+  currentFilters.value = {
+    price: { ...defaults.filters.price },
+    os: [...defaults.filters.os],
+    tags: [...defaults.filters.tags],
+    genre: [...defaults.filters.genre],
+    bpm: { ...defaults.filters.bpm },
+    key: [...defaults.filters.key],
+    mood: [...defaults.filters.mood],
+    year: { ...defaults.filters.year },
+    latestVersionOnly: defaults.filters.latestVersionOnly,
+    status: [...defaults.filters.status],
+  }
+
+  handleFiltersAndSort(defaults)
+}
 
 const handleToggleNav = () => {
   if (navRef.value && navRef.value.toggleMobileNav) {
@@ -566,7 +619,8 @@ const handleFiltersAndSort = (params: FilterSortParams) => {
       key: [...(params.filters.key || [])],
       mood: [...(params.filters.mood || [])],
       year: { ...(params.filters.year || {}) },
-      latestVersionOnly: params.filters.latestVersionOnly ?? false
+      latestVersionOnly: params.filters.latestVersionOnly ?? false,
+      status: [...(params.filters.status || [])],
     }
   }
   
@@ -725,6 +779,8 @@ const openAuthModal = (mode: 'signin' | 'signup' | 'forgot' = 'signin') => {
 
 // Provide functions for child layouts
 provide('openFilterModal', openFilterModal)
+provide('clearFilterSort', clearFilterSort)
+provide('hasActiveFilterSort', hasActiveFilterSortState)
 provide('handleSearch', handleSearch)
 provide('registerSearchHandler', registerSearchHandler)
 provide('unregisterSearchHandler', unregisterSearchHandler)
@@ -750,6 +806,10 @@ onMounted(async () => {
   } catch (error) {
     console.error('Auth init error:', error)
   }
+
+  migrateFilterSortFromLocalStorage('music', musicFilterCookie)
+  migrateFilterSortFromLocalStorage('software', softwareFilterCookie)
+  migrateFilterSortFromLocalStorage('kits', kitsFilterCookie)
 
   openAuthFromQuery()
   

--- a/app/pages/kits/index.vue
+++ b/app/pages/kits/index.vue
@@ -6,7 +6,9 @@
       :count="resourceCount"
       item-label="kit"
       filter-context="kits"
+      :show-clear-filters="hasActiveFilterSort"
       @open-filter-sort="handleOpenFilterSort"
+      @clear-filters="handleClearFilterSort"
     />
     <div class="overflow-x-scroll xl:overflow-auto">
       <DatabaseGrid 
@@ -21,13 +23,37 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, onMounted, onUnmounted, computed } from 'vue'
+import { ref, inject, onMounted, onUnmounted, computed, watch, type ComputedRef } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAuth } from '~/composables/useAuth'
 import DatabaseGrid from '~/components/DatabaseGrid.vue'
 import LibraryHeader from '~/components/LibraryHeader.vue'
 
 const route = useRoute()
+
+// SSR SEO metadata for the kits list page
+const siteOrigin = useSiteOrigin()
+const kitsCanonical = `${siteOrigin}/kits`
+const kitsSeoTitle = 'Music Production Kits & Sample Packs'
+const kitsSeoDescription = 'Browse a curated collection of music production kits, sample packs, and sound libraries for producers, beatmakers, and sound designers.'
+
+useSeoMeta({
+  title: kitsSeoTitle,
+  description: kitsSeoDescription,
+  ogTitle: `${kitsSeoTitle} | Beatbox`,
+  ogDescription: kitsSeoDescription,
+  ogUrl: kitsCanonical,
+  ogType: 'website',
+  twitterCard: 'summary_large_image',
+  twitterTitle: `${kitsSeoTitle} | Beatbox`,
+  twitterDescription: kitsSeoDescription,
+})
+
+useHead({
+  link: [
+    { rel: 'canonical', href: kitsCanonical, key: 'canonical' }
+  ]
+})
 
 // Define interfaces for type safety
 interface FilterSortParams {
@@ -54,6 +80,8 @@ const resourceCount = computed(() => {
 const registerContextItems = inject<(items: any[], fields: string[]) => void>('registerContextItems')
 const unregisterContextItems = inject<() => void>('unregisterContextItems')
 const openFilterModal = inject<() => void>('openFilterModal')
+const clearFilterSort = inject<(() => void) | null>('clearFilterSort', null)
+const hasActiveFilterSort = inject<ComputedRef<boolean>>('hasActiveFilterSort', computed(() => false))
 
 defineEmits(['edit-resource', 'show-signup'])
 
@@ -62,6 +90,10 @@ const handleOpenFilterSort = () => {
   if (openFilterModal) {
     openFilterModal()
   }
+}
+
+const handleClearFilterSort = () => {
+  clearFilterSort?.()
 }
 
 // Watch resources to update context items for search

--- a/app/pages/software/index.vue
+++ b/app/pages/software/index.vue
@@ -6,7 +6,9 @@
       :count="resourceCount"
       item-label="item"
       filter-context="software"
+      :show-clear-filters="hasActiveFilterSort"
       @open-filter-sort="handleOpenFilterSort"
+      @clear-filters="handleClearFilterSort"
     />
     <Database 
       ref="database" 
@@ -19,7 +21,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, inject, onMounted, onUnmounted, computed, watch } from 'vue'
+import { ref, inject, onMounted, onUnmounted, computed, watch, type ComputedRef } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAuth } from '~/composables/useAuth'
 import Database from '~/components/Database.vue'
@@ -31,6 +33,30 @@ definePageMeta({
 })
 
 const route = useRoute()
+
+// SSR SEO metadata for the software list page
+const siteOrigin = useSiteOrigin()
+const softwareCanonical = `${siteOrigin}/software`
+const softwareSeoTitle = 'Music Production Software'
+const softwareSeoDescription = 'Browse a curated collection of music production software — DAWs, synths, samplers, plugins, and audio tools used by producers and engineers.'
+
+useSeoMeta({
+  title: softwareSeoTitle,
+  description: softwareSeoDescription,
+  ogTitle: `${softwareSeoTitle} | Beatbox`,
+  ogDescription: softwareSeoDescription,
+  ogUrl: softwareCanonical,
+  ogType: 'website',
+  twitterCard: 'summary_large_image',
+  twitterTitle: `${softwareSeoTitle} | Beatbox`,
+  twitterDescription: softwareSeoDescription,
+})
+
+useHead({
+  link: [
+    { rel: 'canonical', href: softwareCanonical, key: 'canonical' }
+  ]
+})
 
 // Debug logging
 
@@ -72,6 +98,8 @@ const resourceCount = computed(() => {
 const registerContextItems = inject<(items: any[], fields: string[]) => void>('registerContextItems')
 const unregisterContextItems = inject<() => void>('unregisterContextItems')
 const openFilterModal = inject<() => void>('openFilterModal')
+const clearFilterSort = inject<(() => void) | null>('clearFilterSort', null)
+const hasActiveFilterSort = inject<ComputedRef<boolean>>('hasActiveFilterSort', computed(() => false))
 
 defineEmits(['edit-resource', 'show-signup'])
 
@@ -80,6 +108,10 @@ const handleOpenFilterSort = () => {
   if (openFilterModal) {
     openFilterModal()
   }
+}
+
+const handleClearFilterSort = () => {
+  clearFilterSort?.()
 }
 
 // Watch resources to update context items for search

--- a/app/pages/u/[id].vue
+++ b/app/pages/u/[id].vue
@@ -285,18 +285,30 @@
         <div class="flex flex-col overflow-auto">
           <h2 class="text-lg lg:text-xl font-bold truncate">Music</h2>
         </div>
-        <div class="flex items-stretch gap-4">
+        <div class="flex items-stretch gap-2">
           <p class="text-sm text-neutral-500 flex items-center">
             {{ filteredTracks.length }} {{ filteredTracks.length === 1 ? 'track' : 'tracks' }}
           </p>
-          <Button
-            variant="secondary"
-            size="sm"
-            class="btn px-3! py-1.5! text-sm h-full max-h-10 self-stretch"
-            @click="handleOpenFilterSort"
-          >
-            Filter & Sort
-          </Button>
+          <div id="ui_filter" class="flex items-stretch gap-px group/filter">
+            <Button
+              variant="secondary"
+              size="sm"
+              class="btn px-3! py-1.5! text-sm h-full max-h-10 self-stretch group-hover/filter:bg-neutral-600"
+              @click="handleOpenFilterSort"
+            >
+              Filter & Sort
+            </Button>
+            <Button
+              v-if="hasActiveFilterSort"
+              variant="secondary"
+              size="sm"
+              class="btn px-2.5! py-1.5! text-sm h-full max-h-10 self-stretch shrink-0 group-hover/filter:bg-neutral-600"
+              title="Clear filters"
+              @click="handleClearFilterSort"
+            >
+              <Xmark class="w-4 h-4" />
+            </Button>
+          </div>
           <Button
             v-if="isOwnProfile && isAudioPro"
             variant="secondary"
@@ -341,7 +353,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onActivated, onUnmounted, inject, watch, nextTick } from 'vue'
+import { ref, computed, onMounted, onActivated, onUnmounted, inject, watch, nextTick, type ComputedRef } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAuth } from '~/composables/useAuth'
 import { useSupabase } from '~/utils/supabase'
@@ -356,6 +368,7 @@ import {
   loadStoredAnalyticsRangeLabel,
   useTrackAnalyticsData,
 } from '~/composables/useTrackAnalyticsData'
+import { useFilterSortCookie } from '~/composables/useFilterSortPersistence'
 import { getUniqueGroupTracks } from '~/utils/uniqueGroupShuffle'
 import { usePlayer } from '~/composables/usePlayer'
 import gsap from 'gsap'
@@ -373,6 +386,9 @@ const unregisterContextItems = inject<() => void>('unregisterContextItems')
 const registerFiltersAndSortHandler = inject<(handler: (params: any) => void) => void>('registerFiltersAndSortHandler')
 const unregisterFiltersAndSortHandler = inject<() => void>('unregisterFiltersAndSortHandler')
 const openFilterModal = inject<() => void>('openFilterModal')
+const clearFilterSort = inject<(() => void) | null>('clearFilterSort', null)
+const hasActiveFilterSort = inject<ComputedRef<boolean>>('hasActiveFilterSort', computed(() => false))
+const musicFilterCookie = useFilterSortCookie('music')
 
 // Fetch initial profile data server-side for SEO
 const { data: initialData, refresh: refreshInitialData } = await useAsyncData(
@@ -1437,16 +1453,9 @@ let fetchTracksRequestId = 0
 
 function loadPersistedFilterParams(): { filters: any; sort: any } | null {
   if (lastAppliedParams.value) return lastAppliedParams.value
-  if (typeof window === 'undefined') return null
-  try {
-    const saved = localStorage.getItem('filterSort_music')
-    if (!saved) return null
-    const parsed = JSON.parse(saved)
-    if (!parsed || (!parsed.sort && !parsed.filters)) return null
-    return parsed
-  } catch {
-    return null
-  }
+  const saved = musicFilterCookie.value
+  if (!saved || (!saved.sort && !saved.filters)) return null
+  return saved
 }
 
 function hasActiveMusicFilters(params: { filters?: any }): boolean {
@@ -1537,22 +1546,13 @@ const fetchTracks = async () => {
     loading.value = true
   }
 
-  // Load saved sort preferences from localStorage
+  // Load saved sort preferences from cookie
   let sortBy = 'created_at'
   let sortDirection: 'asc' | 'desc' = 'desc'
-  if (typeof window !== 'undefined') {
-    try {
-      const savedFilters = localStorage.getItem('filterSort_music')
-      if (savedFilters) {
-        const parsed = JSON.parse(savedFilters)
-        if (parsed.sort) {
-          sortBy = parsed.sort.sortBy || 'created_at'
-          sortDirection = parsed.sort.sortDirection || 'desc'
-        }
-      }
-    } catch (e) {
-      console.error('fetchTracks: Error loading saved sort:', e)
-    }
+  const savedFilters = musicFilterCookie.value
+  if (savedFilters?.sort) {
+    sortBy = savedFilters.sort.sortBy || 'created_at'
+    sortDirection = savedFilters.sort.sortDirection || 'desc'
   }
 
   try {
@@ -1740,6 +1740,11 @@ const handleOpenFilterSort = () => {
   if (openFilterModal) {
     openFilterModal()
   }
+}
+
+const handleClearFilterSort = () => {
+  lastAppliedParams.value = null
+  clearFilterSort?.()
 }
 
 // Apply filters and sort to tracks

--- a/app/pages/u/[username]/c/[collection].vue
+++ b/app/pages/u/[username]/c/[collection].vue
@@ -21,7 +21,9 @@
         :analytics-mode="analyticsMode"
         analytics-page="collection"
         filter-context="music"
+        :show-clear-filters="hasActiveFilterSort"
         @open-filter-sort="handleOpenFilterSort"
+        @clear-filters="handleClearFilterSort"
         @open-settings="showSettingsDrawer = true"
         @update:analytics-mode="analyticsMode = $event"
       />
@@ -71,7 +73,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, inject, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, inject, watch, type ComputedRef } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuth } from '~/composables/useAuth'
 import { useSupabase } from '~/utils/supabase'
@@ -88,6 +90,7 @@ import {
   useTrackAnalyticsData,
 } from '~/composables/useTrackAnalyticsData'
 import { getUniqueGroupTracks } from '~/utils/uniqueGroupShuffle'
+import { useFilterSortCookie } from '~/composables/useFilterSortPersistence'
 
 const route = useRoute()
 const router = useRouter()
@@ -103,6 +106,9 @@ const unregisterSearchHandler = inject<() => void>('unregisterSearchHandler')
 const registerFiltersAndSortHandler = inject<(handler: (params: any) => void) => void>('registerFiltersAndSortHandler')
 const unregisterFiltersAndSortHandler = inject<() => void>('unregisterFiltersAndSortHandler')
 const openFilterModal = inject<() => void>('openFilterModal')
+const clearFilterSort = inject<(() => void) | null>('clearFilterSort', null)
+const hasActiveFilterSort = inject<ComputedRef<boolean>>('hasActiveFilterSort', computed(() => false))
+const musicFilterCookie = useFilterSortCookie('music')
 
 // Fetch initial collection data server-side for SEO
 const { data: initialData } = await useAsyncData(
@@ -599,6 +605,11 @@ const handleOpenFilterSort = () => {
   }
 }
 
+const handleClearFilterSort = () => {
+  lastAppliedParams.value = null
+  clearFilterSort?.()
+}
+
 // Apply filter and sort to a list (no fetch). Used when we have unfilteredTracks.
 function applyFiltersAndSortToList(list: any[], params: { filters: any; sort: any }): any[] {
   const { filters, sort } = params
@@ -805,19 +816,10 @@ onMounted(async () => {
     registerFiltersAndSortHandler(updateFiltersAndSort)
   }
 
-  // Apply saved filter/sort from localStorage so initial view matches user preference
-  if (typeof window !== 'undefined') {
-    try {
-      const saved = localStorage.getItem('filterSort_music')
-      if (saved) {
-        const parsed = JSON.parse(saved)
-        if (parsed && (parsed.sort || parsed.filters)) {
-          await updateFiltersAndSort(parsed)
-        }
-      }
-    } catch (e) {
-      console.error('Collection page: Error applying saved filter/sort:', e)
-    }
+  // Apply saved filter/sort from cookie so initial view matches user preference
+  const saved = musicFilterCookie.value
+  if (saved && (saved.sort || saved.filters)) {
+    await updateFiltersAndSort(saved)
   }
 
   // Listen for track updates

--- a/app/pages/u/[username]/g/[group].vue
+++ b/app/pages/u/[username]/g/[group].vue
@@ -42,9 +42,21 @@
             <p class="text-sm text-neutral-500">
               {{ tracks.length }} {{ tracks.length === 1 ? 'track' : 'tracks' }}
             </p>
-            <Button variant="secondary" class="btn !px-3 !py-1.5 text-sm" @click="handleOpenFilterSort">
-              Filter & Sort
-            </Button>
+            <div class="flex items-center gap-1">
+              <Button variant="secondary" class="btn !px-3 !py-1.5 text-sm" @click="handleOpenFilterSort">
+                Filter & Sort
+              </Button>
+              <Button
+                v-if="hasActiveFilterSort"
+                variant="secondary"
+                size="sm"
+                class="btn px-2.5! py-1.5! text-sm shrink-0"
+                title="Clear filters"
+                @click="handleClearFilterSort"
+              >
+                <Xmark class="w-4 h-4" />
+              </Button>
+            </div>
           </div>
         </div>
       </div>
@@ -61,7 +73,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, inject, type ComputedRef } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAuth } from '~/composables/useAuth'
 import { useSupabase } from '~/utils/supabase'
@@ -69,6 +81,8 @@ import TracksTable from '~/components/TracksTable.vue'
 import StemPlayer from '~/components/StemPlayer.vue'
 import LoadingLogo from '~/components/LoadingLogo.vue'
 import LibraryHeader from '~/components/LibraryHeader.vue'
+import { useFilterSortCookie } from '~/composables/useFilterSortPersistence'
+import { Xmark } from '@iconoir/vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -83,11 +97,18 @@ const unregisterContextItems = inject<() => void>('unregisterContextItems')
 const registerFiltersAndSortHandler = inject<(handler: (params: any) => void) => void>('registerFiltersAndSortHandler')
 const unregisterFiltersAndSortHandler = inject<() => void>('unregisterFiltersAndSortHandler')
 const openFilterModal = inject<() => void>('openFilterModal')
+const clearFilterSort = inject<(() => void) | null>('clearFilterSort', null)
+const hasActiveFilterSort = inject<ComputedRef<boolean>>('hasActiveFilterSort', computed(() => false))
+const musicFilterCookie = useFilterSortCookie('music')
 
 const handleOpenFilterSort = () => {
   if (openFilterModal) {
     openFilterModal()
   }
+}
+
+const handleClearFilterSort = () => {
+  clearFilterSort?.()
 }
 
 // Fetch initial group data server-side for SEO
@@ -175,21 +196,14 @@ const fetchGroupTracks = async () => {
     
     profileUserId.value = profileData.id as string
     
-    // Load saved sort preferences from localStorage
+    // Load saved sort preferences from cookie
     let sortBy = 'version'
     let sortDirection: 'asc' | 'desc' = 'desc'
-    
-    try {
-      const savedFilters = localStorage.getItem('filterSort_music')
-      if (savedFilters) {
-        const parsed = JSON.parse(savedFilters)
-        if (parsed.sort) {
-          sortBy = parsed.sort.sortBy || 'version'
-          sortDirection = parsed.sort.sortDirection || 'desc'
-        }
-      }
-    } catch (e) {
-      console.error('Group page: Error loading saved sort:', e)
+
+    const savedFilters = musicFilterCookie.value
+    if (savedFilters?.sort) {
+      sortBy = savedFilters.sort.sortBy || 'version'
+      sortDirection = savedFilters.sort.sortDirection || 'desc'
     }
     
     // Fetch all tracks in this group

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,8 +5,8 @@
   NODE_VERSION = "20.19.0"
   # SEO debug snapshots; omit from secrets scan if re-added accidentally
   SECRETS_SCAN_OMIT_PATHS = "diagnosis-output/**"
-  # Public client env vars are inlined in the bundle by design (not secrets)
-  SECRETS_SCAN_OMIT_KEYS = "NUXT_PUBLIC_POSTHOG_HOST"
+  # Public client env vars / site origin are inlined or hardcoded by design (not secrets)
+  SECRETS_SCAN_OMIT_KEYS = "NUXT_PUBLIC_POSTHOG_HOST,SITE_URL"
 
 [dev]
   targetPort = 3000

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-app",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "nuxt-app",
+  "version": "0.54.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/server/routes/sitemap.xml.ts
+++ b/server/routes/sitemap.xml.ts
@@ -12,8 +12,9 @@ function escapeXml(value: string) {
 }
 
 function urlEntry(loc: string, lastmod?: string | null) {
-  const lastmodTag = lastmod
-    ? `\n    <lastmod>${escapeXml(lastmod.split('T')[0])}</lastmod>`
+  const datePart = lastmod ? lastmod.split('T')[0] ?? lastmod : ''
+  const lastmodTag = datePart
+    ? `\n    <lastmod>${escapeXml(datePart)}</lastmod>`
     : ''
   return `  <url>\n    <loc>${escapeXml(loc)}</loc>${lastmodTag}\n  </url>`
 }
@@ -38,7 +39,13 @@ export default defineEventHandler(async (event) => {
       .eq('status', 'approved')
 
     resources?.forEach((resource) => {
-      const typeSlug = resource.resource_types?.slug
+      const resourceType = resource.resource_types as
+        | { slug: string }
+        | { slug: string }[]
+        | null
+      const typeSlug = Array.isArray(resourceType)
+        ? resourceType[0]?.slug
+        : resourceType?.slug
       if (typeSlug === 'software') {
         resourceRoutes.push({
           loc: `${SITE_ORIGIN}/software/${resource.slug}`,


### PR DESCRIPTION
## Summary
- Server-render `/software` and `/kits` resource lists via `useAsyncData` so crawlers receive detail links in the initial HTML (fixes empty “No resources found” SSR).
- Add list-page SEO metadata (title, description, canonical, Open Graph) using `useSiteOrigin()`.
- Fix TypeScript issues in `sitemap.xml.ts`; add README version history and bump package to `0.54.0`.

## Test plan
- [ ] After deploy, `curl -sL https://beatbox.studio/software | grep -E 'canonical|Music Production Software|/software/'` shows correct meta tags and multiple detail links (no “No resources found” in SSR HTML).
- [ ] Confirm `/kits` SSR HTML similarly includes kit detail links and SEO tags.
- [ ] Filtering/sorting on software and kits still works client-side after hydration.
- [ ] Submit/refresh sitemap in Google Search Console; request indexing on `/software` and a sample software URL.


Made with [Cursor](https://cursor.com)